### PR TITLE
Fit SVG graph to window size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
 * [VS Code color reference](https://code.visualstudio.com/api/references/theme-color)
 
 ## TODO:
-- Add JSON view.
-- Make SVG graph fill window size.
 - Add 'Found no circular dependencies' message.
 - Add tests.
 - Update readme.

--- a/src/classes/WebView.ts
+++ b/src/classes/WebView.ts
@@ -86,13 +86,14 @@ export class WebView {
           <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${webview.cspSource} 'nonce-${nonce}'; style-src ${webview.cspSource};">
           <title>${title || 'Circular dependencies'}</title>
           ${scriptsAndStyles.links}
+          ${scriptsAndStyles.styles}
           <script nonce="${nonce}">
             window.dependencyArray = ${dependencyArrayString};
           </script>
         </head>
         <body>
           <wc-tabs>
-            <nav data-role="tabs">
+            <nav data-role="tabs" id="tabs">
               <button type="button" data-for="panel-graph">Graph view</button>
               <button type="button" data-for="panel-json">JSON view</button>
             </nav>
@@ -101,7 +102,6 @@ export class WebView {
               <pre data-id="panel-json">${dependencyArrayString}</pre>
             </section>
           </wc-tabs>
-          ${scriptsAndStyles.styles}
           ${scriptsAndStyles.scripts}
         </body>
       </html>

--- a/src/webview/classes/Drawer.ts
+++ b/src/webview/classes/Drawer.ts
@@ -15,9 +15,10 @@ import { INode, ILink } from "../../types";
 export class Drawer {
   drawGraph(nodes: INode[], links: ILink[]) {
     // https://observablehq.com/@d3/disjoint-force-directed-graph
+    const tabsHeight = document.getElementById('tabs')?.getBoundingClientRect().height;
     const svgOptions = {
       width: 100,
-      height: 100,
+      height: (window.innerHeight - (tabsHeight || 0)) / window.innerWidth * 100,
     };
     const longestFileNameLength = nodes.sort((a,b) => b.filename.length - a.filename.length)[0]?.filename.length || 10;
     const longestSupportedFileNameLength = 200;
@@ -41,6 +42,7 @@ export class Drawer {
       )
       .style('width', '100%')
       .style('height', 'auto')
+      .style('display', 'block') // Fill available space.
       .call(zoom<SVGSVGElement, INode>().on('zoom', function(event) {
         group.attr('transform', event.transform);
       }));

--- a/src/webview/webview.scss
+++ b/src/webview/webview.scss
@@ -1,3 +1,10 @@
+html {
+  /* VS Code seems to show scrollbar even when no scroll is possible, so we fix. */
+  overflow: hidden;
+}
+
 body {
+  height: 100vh;
   padding: 0;
+  overflow: auto;
 }


### PR DESCRIPTION
Worth mentioning is that window size is only calculated when webview initializes; it does not re-calculate on window resize. Don't consider this very important, as the user can interact (zoom and pan) with the graph itself in order to view all of it.