### PR TITLE
Add tests for DependencyFinder.findCircular.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,8 +22,10 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"args": [
+        "${workspaceFolder}/src/test/workspace",
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+				"--disable-extensions"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,7 @@
 		{
 			"label": "tasks: watch-tests",
 			"dependsOn": [
-				"npm: watch",
+				// "npm: watch",
 				"npm: watch-tests"
 			],
 			"problemMatcher": []

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Find circular dependencies in your project. Supports the following filetypes:
 - .less
 
 ## How to use
-1. Open the command palette (View -> Command Palette, or `cmd` + `shift` + `p` on macOS, `ctrl` + `shift` + `p` on Windows).
+1. Open the command palette (View -> Command Palette, or <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> on macOS, <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> on Windows).
 2. Type `circular dependencies` and select the command you wish to run.
 
 \!\[Demonstrating how to use the plugin\]\(images/demo.gif\)
@@ -22,14 +22,27 @@ Find circular dependencies in your project. Supports the following filetypes:
 ### 1.0.0
 Initial release.
 
------------------------------------------------------------------------------------------------------------
-## Following extension guidelines
-
-Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
-
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-
 ## Developing the plugin
+1. `npm i`.
+2. Open the repo in VS Code. 
+3. Open `Run and Debug` in the sidebar and select `Run Extension`. Alternatively, press <kbd>f5</kbd>.
+   This starts watching for file changes and opens the `Extension Development Host` window, 
+   where the extension is available for use. If you get a `Cannot find module` error,
+   just reload the `Extension Development Host`; this happens when trying to activate the 
+   extension before the source files are built.
+4. Make changes to the plugin code.
+5. Reload the `Extension Development Host` (<kbd>cmd</kbd> + <kbd>r</kbd> on macOS, 
+   <kbd>ctrl</kbd> + <kbd>r</kbd> on Windows) for the changes to take effect.
+
+### Testing
+1. `npm i`.
+2. Open the repo in VS Code. 
+3. Open `Run and Debug` in the sidebar and select `Extension Tests`. Alternatively, press <kbd>f5</kbd>.
+   This starts watching for file changes and opens the `Extension Development Host` window, 
+   where the tests will be run.
+4. Make changes to the test code.
+5. Repeat step 3 to rerun tests.
+
 ### Get intellisense for CSS modules
 https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
 
@@ -38,7 +51,6 @@ https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
 * [VS Code color reference](https://code.visualstudio.com/api/references/theme-color)
 
 ## TODO:
-- Add tests.
 - Update readme with animation on how to use the plugin.
 - Publish.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch": "rm -rf dist && webpack --mode development --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
     "compile-tests": "tsc -p . --outDir out",
-    "watch-tests": "tsc -p -w . --outDir out",
+    "watch-tests": "rm -rf out && tsc -w -p . --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js"

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,41 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import { DependencyFinder } from '../../classes/DependencyFinder';
+
+const dependencyFinder = new DependencyFinder(vscode.window, vscode.ProgressLocation);
+const fileExtensionsToTest = ['css', 'less', 'scss', 'ts'];
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  suite('DependencyFinder.findCircular() should return an array of circular dependencies', () => {
+
+    fileExtensionsToTest.forEach((ext) => {
+      test(
+      `for a given .${ext} file`, 
+      async () => {
+        const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
+          ? vscode.workspace.workspaceFolders?.[0].uri.path + `/index.${ext}`
+          : null;
+
+        if (!filePath) {
+          assert.fail(`No index.${ext} file found. Did you forget to load a workspace?`);
+        }
+        
+        const circularDependencies = await dependencyFinder.findCircular(filePath);
+
+        assert.ok(JSON.stringify(circularDependencies) === JSON.stringify([
+          [
+            `a/a.${ext}`,
+            `b/b.${ext}`,
+          ],
+          [
+            `e/e.${ext}`,
+            `f/f.${ext}`,
+            `d/d.${ext}`,
+          ],
+        ]));
+      });
+    });
+  });
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -11,27 +11,27 @@ export function run(): Promise<void> {
 
 	const testsRoot = path.resolve(__dirname, '..');
 
-	return new Promise((c, e) => {
+	return new Promise((resolve, reject) => {
 		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
 			if (err) {
-				return e(err);
+				return reject(err);
 			}
 
 			// Add files to the test suite
-			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+			files.forEach(file => mocha.addFile(path.resolve(testsRoot, file)));
 
 			try {
 				// Run the mocha test
-				mocha.run(failures => {
-					if (failures > 0) {
-						e(new Error(`${failures} tests failed.`));
+				mocha.run(failCount => {
+					if (failCount > 0) {
+						reject(new Error(`${failCount} tests failed.`));
 					} else {
-						c();
+						resolve();
 					}
 				});
 			} catch (err) {
 				console.error(err);
-				e(err);
+				reject(err);
 			}
 		});
 	});

--- a/src/test/workspace/a/a.css
+++ b/src/test/workspace/a/a.css
@@ -1,0 +1,5 @@
+@import '../b/b.css';
+
+.a {
+  color: #aaa;
+}

--- a/src/test/workspace/a/a.less
+++ b/src/test/workspace/a/a.less
@@ -1,0 +1,5 @@
+@import '../b/b';
+
+.a {
+  color: #aaa;
+}

--- a/src/test/workspace/a/a.scss
+++ b/src/test/workspace/a/a.scss
@@ -1,0 +1,5 @@
+@import '../b/b';
+
+.a {
+  color: #aaa;
+}

--- a/src/test/workspace/a/a.ts
+++ b/src/test/workspace/a/a.ts
@@ -1,0 +1,5 @@
+import { b } from '../b/b';
+
+export function a() {
+  console.info('a() calls b', b());
+}

--- a/src/test/workspace/b/b.css
+++ b/src/test/workspace/b/b.css
@@ -1,0 +1,5 @@
+@import '../a/a.css';
+
+.b {
+  color: #aaa;
+}

--- a/src/test/workspace/b/b.less
+++ b/src/test/workspace/b/b.less
@@ -1,0 +1,5 @@
+@import '../a/a';
+
+.b {
+  color: #aaa;
+}

--- a/src/test/workspace/b/b.scss
+++ b/src/test/workspace/b/b.scss
@@ -1,0 +1,5 @@
+@import '../a/a';
+
+.b {
+  color: #aaa;
+}

--- a/src/test/workspace/b/b.ts
+++ b/src/test/workspace/b/b.ts
@@ -1,0 +1,5 @@
+import { a } from "../a/a";
+
+export function b() {
+  console.info('b() calls a', a());
+}

--- a/src/test/workspace/c/c.css
+++ b/src/test/workspace/c/c.css
@@ -1,0 +1,5 @@
+@import '../e/e.css';
+
+.c {
+  color: #aaa;
+}

--- a/src/test/workspace/c/c.less
+++ b/src/test/workspace/c/c.less
@@ -1,0 +1,5 @@
+@import '../e/e';
+
+.c {
+  color: #aaa;
+}

--- a/src/test/workspace/c/c.scss
+++ b/src/test/workspace/c/c.scss
@@ -1,0 +1,5 @@
+@import '../e/e';
+
+.c {
+  color: #aaa;
+}

--- a/src/test/workspace/c/c.ts
+++ b/src/test/workspace/c/c.ts
@@ -1,0 +1,5 @@
+import { e } from "../e/e";
+
+export function c() {
+  console.info('c() calls e', e());
+}

--- a/src/test/workspace/d/d.css
+++ b/src/test/workspace/d/d.css
@@ -1,0 +1,5 @@
+@import '../e/e.css';
+
+.d {
+  color: #aaa;
+}

--- a/src/test/workspace/d/d.less
+++ b/src/test/workspace/d/d.less
@@ -1,0 +1,5 @@
+@import '../e/e';
+
+.d {
+  color: #aaa;
+}

--- a/src/test/workspace/d/d.scss
+++ b/src/test/workspace/d/d.scss
@@ -1,0 +1,5 @@
+@import '../e/e';
+
+.d {
+  color: #aaa;
+}

--- a/src/test/workspace/d/d.ts
+++ b/src/test/workspace/d/d.ts
@@ -1,0 +1,5 @@
+import { e } from "../e/e";
+
+export function d() {
+  console.info('d() calls e', e());
+}

--- a/src/test/workspace/e/e.css
+++ b/src/test/workspace/e/e.css
@@ -1,0 +1,5 @@
+@import '../f/f.css';
+
+.e {
+  color: #aaa;
+}

--- a/src/test/workspace/e/e.less
+++ b/src/test/workspace/e/e.less
@@ -1,0 +1,5 @@
+@import '../f/f';
+
+.e {
+  color: #aaa;
+}

--- a/src/test/workspace/e/e.scss
+++ b/src/test/workspace/e/e.scss
@@ -1,0 +1,5 @@
+@import '../f/f';
+
+.e {
+  color: #aaa;
+}

--- a/src/test/workspace/e/e.ts
+++ b/src/test/workspace/e/e.ts
@@ -1,0 +1,5 @@
+import { f } from '../f/f';
+
+export function e() {
+  console.info('e() calls f', f());
+}

--- a/src/test/workspace/f/f.css
+++ b/src/test/workspace/f/f.css
@@ -1,0 +1,5 @@
+@import '../d/d.css';
+
+.f {
+  color: #aaa;
+}

--- a/src/test/workspace/f/f.less
+++ b/src/test/workspace/f/f.less
@@ -1,0 +1,5 @@
+@import '../d/d';
+
+.f {
+  color: #aaa;
+}

--- a/src/test/workspace/f/f.scss
+++ b/src/test/workspace/f/f.scss
@@ -1,0 +1,5 @@
+@import '../d/d';
+
+.f {
+  color: #aaa;
+}

--- a/src/test/workspace/f/f.ts
+++ b/src/test/workspace/f/f.ts
@@ -1,0 +1,5 @@
+import { d } from '../d/d';
+
+export function f() {
+  console.info('f() calls d', d());
+}

--- a/src/test/workspace/index.css
+++ b/src/test/workspace/index.css
@@ -1,0 +1,2 @@
+@import './a/a.css';
+@import './c/c.css';

--- a/src/test/workspace/index.less
+++ b/src/test/workspace/index.less
@@ -1,0 +1,2 @@
+@import './a/a';
+@import './c/c';

--- a/src/test/workspace/index.scss
+++ b/src/test/workspace/index.scss
@@ -1,0 +1,2 @@
+@import './a/a';
+@import './c/c';

--- a/src/test/workspace/index.ts
+++ b/src/test/workspace/index.ts
@@ -1,0 +1,13 @@
+import { a } from './a/a';
+import { b } from './b/b';
+import { c } from './c/c';
+import { d } from './d/d';
+
+a();
+b();
+c();
+d();
+
+export function index() {
+  console.info('index()');
+}


### PR DESCRIPTION
All files in `src/test/workspace` are workspace files used in the tests for finding circular dependencies.
This PR also updates readme with information on local development and testing.