### PR TITLE
Feature/add search

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -10,6 +10,8 @@
 5. Reload the `Extension Development Host` (<kbd>cmd</kbd> + <kbd>r</kbd> on macOS, 
    <kbd>ctrl</kbd> + <kbd>r</kbd> on Windows) for the changes to take effect.
 
+> Tip: Open the VS Code devtools with Help -> Toggle Developer Tools.
+
 ## Testing
 1. `npm i`.
 2. Open the repo in VS Code. 
@@ -17,7 +19,8 @@
    This starts watching for file changes and opens the `Extension Development Host` window, 
    where the tests will be run.
 4. Make changes to the test code.
-5. Repeat step 3 to rerun tests.
+5. Test results are output to the debug console in the original window.
+6. Repeat step 3 to rerun tests.
 
 ## Get intellisense for CSS modules
 https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
@@ -25,8 +28,10 @@ https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
 ## Helpful links
 - [How To Publish VS Code extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)
 - [VS Code color reference](https://code.visualstudio.com/api/references/theme-color)
+- [VS Code webview](https://code.visualstudio.com/api/extension-guides/webview)
 - [Write good changelogs](http://keepachangelog.com/)
 - [Learn D3](https://observablehq.com/@d3/learn-d3?collection=@d3/learn-d3)
 
 # TODO:
+- Disable search (cmd/ctrl+f) on graph view. Alternatively enable "search to highlight" there as well (if so, move event listeners away from JsonSearchComponent).
 - Publish.

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -33,5 +33,4 @@ https://www.npmjs.com/package/typescript-plugin-css-modules#visual-studio-code
 - [Learn D3](https://observablehq.com/@d3/learn-d3?collection=@d3/learn-d3)
 
 # TODO:
-- Disable search (cmd/ctrl+f) on graph view. Alternatively enable "search to highlight" there as well (if so, move event listeners away from JsonSearchComponent).
 - Publish.

--- a/src/classes/WebView.ts
+++ b/src/classes/WebView.ts
@@ -52,7 +52,7 @@ export class WebView {
     return panel;
   }
 
-  private generateNonce() {
+  private static generateNonce() {
     const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     let nonce = '';
     for (let i = 0; i < 32; ++i) {
@@ -67,7 +67,7 @@ export class WebView {
    */
   getHtml({dependencyArray, extensionPath, title, webview}: IGetWebViewProps) {
     const dependencyArrayString = JSON.stringify(dependencyArray, null, 2);
-    const nonce = this.generateNonce();
+    const nonce = WebView.generateNonce();
 
     const getScriptsAndStyles = () => {
       /**

--- a/src/classes/WebView.ts
+++ b/src/classes/WebView.ts
@@ -117,7 +117,7 @@ export class WebView {
               <button type="button" data-for="panel-json">JSON view</button>
             </nav>
             <section data-role="panels">
-              <svg data-id="panel-graph"></svg>
+              <wc-graph data-id="panel-graph"></wc-graph>
               <wc-json data-id="panel-json" json='${dependencyArrayString}'></wc-json>
             </section>
           </wc-tabs>

--- a/src/classes/WebView.ts
+++ b/src/classes/WebView.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { join } from 'path';
+import { IMessageEventPayload } from '../types';
 
 interface IGetWebViewProps {
   dependencyArray: string[][];
@@ -9,15 +10,15 @@ interface IGetWebViewProps {
 }
 
 export class WebView {
-  static type: 'circularDependencies' = 'circularDependencies';
+  static type = 'circularDependencies' as const;
 
   constructor(
     private vsCode: Pick<typeof vscode, 'window' | 'ViewColumn' | 'Uri'>,
     private extensionContext: Pick<vscode.ExtensionContext, 'extensionPath'>
   ) { }
 
-  create(dependencyArray: string[][], title: string) {
-    const panel = this.vsCode.window.createWebviewPanel(WebView.type, title, this.vsCode.ViewColumn.One, {
+  createPanel(dependencyArray: string[][], title: string, addTo?: vscode.WebviewPanel) {
+    const panel = addTo || this.vsCode.window.createWebviewPanel(WebView.type, title, this.vsCode.ViewColumn.One, {
       localResourceRoots: [
         vscode.Uri.file(join(this.extensionContext.extensionPath, 'dist/webview'))
       ],
@@ -28,6 +29,24 @@ export class WebView {
       extensionPath: this.extensionContext.extensionPath,
       webview: panel.webview,
       title,
+    });
+
+    panel.webview.onDidReceiveMessage(async (message: IMessageEventPayload) => {
+      switch(message.type) {
+        case 'initSearch': {
+          const searchQuery = await this.vsCode.window.showInputBox({
+            title: 'Find filename in circular dependencies',
+            placeHolder: 'Find',
+          });
+          panel.webview.postMessage({
+            type: 'search', 
+            data: searchQuery,
+          } as IMessageEventPayload);
+        }
+        default: {
+          return;
+        }
+      }
     });
 
     return panel;
@@ -99,7 +118,7 @@ export class WebView {
             </nav>
             <section data-role="panels">
               <svg data-id="panel-graph"></svg>
-              <pre data-id="panel-json">${dependencyArrayString}</pre>
+              <wc-json data-id="panel-json" json='${dependencyArrayString}'></wc-json>
             </section>
           </wc-tabs>
           ${scriptsAndStyles.scripts}

--- a/src/classes/WebViewSerializer.ts
+++ b/src/classes/WebViewSerializer.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { IState } from '../types';
 import { WebView } from './WebView';
 
 /**
@@ -11,12 +12,11 @@ export class WebViewSerializer implements vscode.WebviewPanelSerializer {
     private extensionContext: Pick<vscode.ExtensionContext, 'extensionPath'>
   ) { }
 
-  async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: Record<string, any>) {
-    webviewPanel.webview.html = new WebView(this.vsCode, this.extensionContext).getHtml({
-      dependencyArray: state.dependencyArray,
-      extensionPath: this.extensionContext.extensionPath,
-      title: webviewPanel.title,
-      webview: webviewPanel.webview,
-    });
+  async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, state: IState) {
+    new WebView(this.vsCode, this.extensionContext).createPanel(
+      state.dependencyArray,
+      webviewPanel.title,
+      webviewPanel
+    );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
           filePath
         );
 
-      new WebView(vscode, context).create(
+      new WebView(vscode, context).createPanel(
         circularDependencies,
         `Circular Dependencies: ${filePath.split('/').reverse()[0]}`
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,12 @@
 import { SimulationNodeDatum, SimulationLinkDatum } from "d3";
 
-type IFileId = string;
+type TFileId = string;
+
+export type TJsonData = string;
 
 export interface INode extends SimulationNodeDatum {
   filename: string;
-  id: IFileId;
+  id: TFileId;
 }
 
 export type TDependencyArray = string[][];
@@ -12,11 +14,21 @@ export type TDependencyArray = string[][];
 export type TNodeArray = INode[][];
 
 export interface ILink extends SimulationLinkDatum<INode> {
-  source: IFileId | INode;
-  target: IFileId | INode;
+  source: TFileId | INode;
+  target: TFileId | INode;
 }
 
 export interface IGraphData {
   links: ILink[];
   nodes: INode[];
+}
+
+export interface IMessageEventPayload<D = any> {
+  type: 'initSearch' | 'search';
+  data?: D;
+}
+
+export interface IState {
+  dependencyArray: TDependencyArray;
+  search?: string;
 }

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,15 +1,12 @@
+import { IMessageEventPayload, IState, TDependencyArray } from "../types";
+
 declare global {
-  // interface Window {
-  //   dependencyArray: string[][];
-  // }
   namespace globalThis {
-    var dependencyArray: string[][];
+    var dependencyArray: TDependencyArray;
     var acquireVsCodeApi: () => {
-      getState: () => Record<string, any>;
-      postMessage: (message: string, transfer: any) => void;
-      setState: (newState: Record<string, any>) => void;
+      getState: () => IState;
+      postMessage: <D = any>(payload: IMessageEventPayload<D>) => void;
+      setState: (newState: IState) => void;
     }
   }
 }
-
-export {}

--- a/src/webview/classes/Drawer.ts
+++ b/src/webview/classes/Drawer.ts
@@ -75,6 +75,7 @@ export class Drawer {
       .selectAll<SVGCircleElement, INode>('circle')
       .data(nodes)
       .join('circle')
+      .attr('data-value', (d) => d.filename)
       .attr('r', nodeRadius)
       .call(handleDrag(simulation));
 

--- a/src/webview/classes/EventListeners.ts
+++ b/src/webview/classes/EventListeners.ts
@@ -1,0 +1,33 @@
+interface IListenerAdder {
+	add: () => void;
+	remove: () => void;
+}
+
+export class EventListeners {
+	private static instance: EventListeners;
+	private static active: boolean = false;
+
+	constructor (private listenerAdders: IListenerAdder[]) {
+		if (EventListeners.instance) {
+			return EventListeners.instance;
+		}
+
+		EventListeners.instance = this;
+	}
+
+	add() {
+		if (EventListeners.active) {
+			return;
+		}
+
+		this.listenerAdders.forEach((adder) => adder.add());
+
+		EventListeners.active = true;
+	}
+
+	remove() {
+		this.listenerAdders.forEach((adder) => adder.remove());
+
+		EventListeners.active = false;
+	}
+}

--- a/src/webview/classes/MessageEventListeners.ts
+++ b/src/webview/classes/MessageEventListeners.ts
@@ -1,0 +1,40 @@
+import { IMessageEventPayload } from "../../types";
+import { vscode } from "../vscode-api";
+
+export class MessageEventListeners {
+	private static active: boolean = false;
+
+	constructor () {
+		throw Error('MessageEventListeners cannot be instantiated. Use it\'s static methods instead.');
+	}
+
+	static add() {
+		if (MessageEventListeners.active) {
+			return;
+		}
+
+		window.addEventListener('message', handleMessage);
+
+		MessageEventListeners.active = true;
+	}
+
+	static remove() {
+		window.removeEventListener('message', handleMessage);
+
+		MessageEventListeners.active = false;
+	}
+}
+
+function handleMessage(event: MessageEvent<IMessageEventPayload<string>>) {
+	switch(event.data.type) {
+		case 'search': {
+			vscode.setState({
+				...vscode.getState(),
+				search: event.data.data,
+			});
+		}
+		default: {
+			return;
+		}
+	}
+}

--- a/src/webview/classes/SearchEventListeners.ts
+++ b/src/webview/classes/SearchEventListeners.ts
@@ -1,0 +1,40 @@
+import { vscode } from "../vscode-api";
+
+export class SearchEventListeners {
+	private static active: boolean = false;
+
+	constructor () {
+		throw Error('SearchEventListeners cannot be instantiated. Use it\'s static methods instead.');
+	}
+
+	static add() {
+		if (SearchEventListeners.active) {
+			return;
+		}
+
+		window.addEventListener('keydown', handleKeyDown);
+
+		SearchEventListeners.active = true;
+	}
+
+	static remove() {
+		window.removeEventListener('keydown', handleKeyDown);
+
+		SearchEventListeners.active = false;
+	}
+}
+
+function handleKeyDown(event: KeyboardEvent) {
+	if (
+		event.key.toLocaleLowerCase() !== 'f' 
+		|| !event.metaKey 
+		|| event.shiftKey 
+		|| event.altKey
+	) {
+		return;
+	}
+
+	vscode.postMessage({
+		type: 'initSearch',
+	});
+}

--- a/src/webview/components/graph-component.scss
+++ b/src/webview/components/graph-component.scss
@@ -1,0 +1,3 @@
+.highlight {
+	fill: var(--vscode-editor-findMatchBackground);
+}

--- a/src/webview/components/graph-component.ts
+++ b/src/webview/components/graph-component.ts
@@ -12,8 +12,22 @@ import {
 import { isNodeWithXandY } from "../../type-guards";
 import { INode, ILink } from "../../types";
 
-export class Drawer {
-  drawGraph(nodes: INode[], links: ILink[], nodesEmptyMsg?: string) {
+let instanceCount = 0;
+
+export class GraphComponent extends HTMLElement {
+	dataId!: string;
+
+	constructor() {
+		super();
+		
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		this.dataId = (instanceCount++).toString();
+
+		this.append(svg);
+		this.setAttribute('data-graph-id', this.dataId);
+	}
+	
+	drawGraph(nodes: INode[], links: ILink[], nodesEmptyMsg?: string) {
     // https://observablehq.com/@d3/disjoint-force-directed-graph
     const tabsHeight = document.getElementById('tabs')?.getBoundingClientRect().height;
     const svgOptions = {
@@ -36,7 +50,7 @@ export class Drawer {
       .force('x', forceX())
       .force('y', forceY());
 
-    const svg = select<SVGSVGElement, INode>('svg')
+    const svg = select<SVGSVGElement, INode>(`wc-graph[data-graph-id="${this.dataId}"] svg`)
       .attr('viewBox', 
         `${-svgOptions.width / 2} ${-svgOptions.height / 2} ${svgOptions.width} ${svgOptions.height}`
       )
@@ -137,7 +151,8 @@ export class Drawer {
         .on('start', dragStarted)
         .on('drag', dragged)
         .on('end', dragEnded);
-    }
-      
+    } 
   }
 }
+
+!customElements.get('wc-graph') && customElements.define('wc-graph', GraphComponent);

--- a/src/webview/components/json-component.scss
+++ b/src/webview/components/json-component.scss
@@ -1,0 +1,10 @@
+.viewer {
+	white-space: pre-wrap;
+	word-break: break-word;
+	padding: 10px;
+	display: block;
+}
+
+.highlight {
+	background-color: var(--vscode-editor-findMatchBackground);
+}

--- a/src/webview/components/json-component.ts
+++ b/src/webview/components/json-component.ts
@@ -39,7 +39,7 @@ class JsonComponent extends HTMLElement {
 		window.removeEventListener('message', this.handleMessage);
 	}
 
-	handleMessage(event: MessageEvent<IMessageEventPayload<string>>) {
+	private handleMessage(event: MessageEvent<IMessageEventPayload<string>>) {
 		switch(event.data.type) {
 			case 'search': {
 				this.search(event.data.data || '');
@@ -50,7 +50,7 @@ class JsonComponent extends HTMLElement {
 		}
 	}
 
-	search(query: string) {
+	private search(query: string) {
 		const queryLowerCase = query.toLocaleLowerCase();
 
 		this.querySelectorAll('.dep').forEach((el) => {

--- a/src/webview/components/json-component.ts
+++ b/src/webview/components/json-component.ts
@@ -1,0 +1,66 @@
+import styles from './json-component.scss';
+import { IMessageEventPayload, TJsonData, TDependencyArray } from '../../types';
+
+class JsonComponent extends HTMLElement {
+	static get observedAttributes() {
+		return ['json'];
+	}
+
+	constructor() {
+		super();
+
+		this.classList.add(styles.viewer);
+		this.handleMessage = this.handleMessage.bind(this);
+	}
+
+	attributeChangedCallback(attr: 'json', oldVal: TJsonData | undefined, newVal: TJsonData | undefined) {
+		try {
+			if (!newVal) {
+				throw Error('Missing required "json" attribute.');
+			}
+
+			const parsed: TDependencyArray = JSON.parse(newVal);
+			const mapped = parsed.map((circularDeps) => {
+				return circularDeps.map((dep) => {
+					return `<span class='dep'>${dep}</span>`;
+				});
+			});
+			this.innerHTML = JSON.stringify(mapped, null, 2);
+		} catch (error) {
+			this.innerHTML = '<p>Found no circular dependencies</p>';
+		}
+	}
+
+	connectedCallback() {
+		window.addEventListener('message', this.handleMessage);
+	}
+	
+	disconnectedCallback() {
+		window.removeEventListener('message', this.handleMessage);
+	}
+
+	handleMessage(event: MessageEvent<IMessageEventPayload<string>>) {
+		switch(event.data.type) {
+			case 'search': {
+				this.search(event.data.data || '');
+			}
+			default: {
+				return;
+			}
+		}
+	}
+
+	search(query: string) {
+		const queryLowerCase = query.toLocaleLowerCase();
+
+		this.querySelectorAll('.dep').forEach((el) => {
+			el.classList.remove(styles.highlight);
+
+			if (queryLowerCase && el.innerHTML.toLocaleLowerCase().includes(queryLowerCase)) {
+				el.classList.add(styles.highlight);
+			}
+		});
+	}
+}
+
+!customElements.get('wc-json') && customElements.define('wc-json', JsonComponent);

--- a/src/webview/vscode-api.ts
+++ b/src/webview/vscode-api.ts
@@ -1,0 +1,2 @@
+// https://code.visualstudio.com/api/extension-guides/webview#persistence
+export const vscode = acquireVsCodeApi();

--- a/src/webview/webview.ts
+++ b/src/webview/webview.ts
@@ -1,12 +1,15 @@
 import './webview.scss';
+import './components/json-component';
 import './components/tabs-component';
 import { DataFormatter } from './classes/DataFormatter';
 import { Drawer } from './classes/Drawer';
-
-// https://code.visualstudio.com/api/extension-guides/webview#persistence
-const vscode = acquireVsCodeApi();
+import { vscode } from './vscode-api';
+import { SearchEventListeners } from './classes/SearchEventListeners';
+import { MessageEventListeners } from './classes/MessageEventListeners';
+import { EventListeners } from './classes/EventListeners';
 
 function init() {
+  new EventListeners([SearchEventListeners, MessageEventListeners]).add();
   const dataFormatter = new DataFormatter();
   const drawer = new Drawer();
   // VS Code makes dependencyArray available to us.

--- a/src/webview/webview.ts
+++ b/src/webview/webview.ts
@@ -1,22 +1,22 @@
 import './webview.scss';
+import './components/graph-component';
 import './components/json-component';
 import './components/tabs-component';
 import { DataFormatter } from './classes/DataFormatter';
-import { Drawer } from './classes/Drawer';
 import { vscode } from './vscode-api';
 import { SearchEventListeners } from './classes/SearchEventListeners';
 import { MessageEventListeners } from './classes/MessageEventListeners';
 import { EventListeners } from './classes/EventListeners';
+import { GraphComponent } from './components/graph-component';
 
 function init() {
   new EventListeners([SearchEventListeners, MessageEventListeners]).add();
   const dataFormatter = new DataFormatter();
-  const drawer = new Drawer();
   // VS Code makes dependencyArray available to us.
   const { links, nodes } = dataFormatter.dependencyArrayToGraphData(dependencyArray);
 
   vscode.setState({dependencyArray});
-  drawer.drawGraph(nodes, links, 'Found no circular dependencies');
+  document.querySelector<GraphComponent>('wc-graph')?.drawGraph(nodes, links, 'Found no circular dependencies');
 }
 
 init();


### PR DESCRIPTION
This PR adds support for cmd/ctrl+f for searching in the circular dependencies result set. Search results will be highlighted with a different background color. Works in both graph view and JSON view. This fixes point 1 in https://github.com/olefjaerestad/vscode-circular-dependencies-finder/issues/7.

The PR also improves typings.