### PR TITLE
Hide filepath, and display only filename, in graph view.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ type TFileId = string;
 export type TJsonData = string;
 
 export interface INode extends SimulationNodeDatum {
-  filename: string;
+  filepath: string;
   id: TFileId;
 }
 

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Extracts the filename from a filepath.
+ */
+export function filename(filepath: string) {
+ const slash = filepath.includes('\\') ? '\\' : '/';
+ const lastSlashIndex = filepath.lastIndexOf(slash);
+ 
+ return lastSlashIndex !== -1 
+	 ? filepath.substring(lastSlashIndex + 1, filepath.length)
+	 : filepath;
+}

--- a/src/webview/classes/DataFormatter.ts
+++ b/src/webview/classes/DataFormatter.ts
@@ -13,7 +13,7 @@ export class DataFormatter {
   private dependencyArrayToNodeTree(deps: TDependencyArray): TNodeArray {
     return deps.map((subtree, i) => {
       return subtree.map((dep, j) => ({
-        filename: dep,
+        filepath: dep,
         id: `${i}-${j}`
       }));
     });

--- a/src/webview/components/graph-component.ts
+++ b/src/webview/components/graph-component.ts
@@ -12,6 +12,7 @@ import {
 } from "d3";
 import { isNodeWithXandY } from "../../type-guards";
 import { INode, ILink, IMessageEventPayload } from "../../types";
+import { filename } from '../../utils/string-utils';
 
 let instanceCount = 0;
 
@@ -45,8 +46,14 @@ export class GraphComponent extends HTMLElement {
       width: 100,
       height: (window.innerHeight - (tabsHeight || 0)) / window.innerWidth * 100,
     };
-    const longestFileNameLength = nodes.sort((a,b) => b.filename.length - a.filename.length)[0]?.filename.length || 10;
-    const longestSupportedFileNameLength = 200;
+    const longestFileNameLength = nodes.length 
+      ? filename(
+          nodes.sort(
+            (a,b) => filename(b.filepath).length - filename(a.filepath).length
+          )[0].filepath
+        ).length
+      : 10;
+    const longestSupportedFileNameLength = 100;
     const nodeRadius = 4 + (Math.min(longestFileNameLength / longestSupportedFileNameLength, 1) * 4);
     const minFontSize = .2;
     const maxFontSize = 2;
@@ -100,7 +107,7 @@ export class GraphComponent extends HTMLElement {
       .selectAll<SVGCircleElement, INode>('circle')
       .data(nodes)
       .join('circle')
-      .attr('data-value', (d) => d.filename)
+      .attr('data-value', (d) => d.filepath)
       .attr('r', nodeRadius)
       .call(handleDrag(simulation));
 
@@ -113,10 +120,10 @@ export class GraphComponent extends HTMLElement {
       .selectAll('text')
       .data(nodes)
       .join('text')
-      .text((d) => d.filename);
+      .text((d) => filename(d.filepath));
 
     node.append('title')
-      .text((d) => d.filename);
+      .text((d) => d.filepath);
 
     simulation.on('tick', () => {
       link


### PR DESCRIPTION
This PR hides the filepaths in the graph view, and displays only the filenames instead. This lets us increase the font size, making the filenames more legible. The filepaths are still displayed as title tooltips when hovering over the nodes in the graph. The JSON view is unaffected by this change; it still displays the filepaths.

This fixes point 2 in https://github.com/olefjaerestad/vscode-circular-dependencies-finder/issues/7.