### PR TITLE
#12, #16: Add 'Find circular dependencies in current file' option. Add setting for excluding 'import type' statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,24 @@ Releases follow [Semantic Versioning](https://semver.org/)
 - No upcoming plans. Feel free to submit issues to 
   https://github.com/olefjaerestad/vscode-circular-dependencies-finder/issues.
 
+# 1.2.0 - 2024-07-25
+
+- Add setting ('circularDependenciesFinder.excludeTypeImports') for excluding 
+  'import type' statements when calculating circular dependencies.
+- Add 'Find circular dependencies in current file' option to 'Find circular 
+  dependencies' command.
+
 # 1.1.1 - 2024-03-14
 
 - Add support for special characters in filepaths.
 
 # 1.1.0 - 2022-03-20
 
-- Adds "search in circular dependencies" with `cmd/ctrl+f`.
-- Hides filepaths from graph view.
+- Add "search in circular dependencies" with `cmd/ctrl+f`.
+- Hide filepaths from graph view.
 
 # 1.0.0 - 2021-10-30
 
-- Initial release
-- Adds a `Find Circular Dependencies` command, which will display a graph and JSON view of 
-  your circular dependencies based on a selected root file.
+- Initial release.
+- Add `Find Circular Dependencies` command, which will display a graph and JSON 
+  view of your circular dependencies based on a selected root file.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Recursively find circular dependencies in your project. Supports the following f
 1. Open the command palette (View -> Command Palette, or <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> on macOS, <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> on Windows).
 2. Type `circular dependencies` and select the command you wish to run.
 
+## Settings
+
+### `circularDependenciesFinder.excludeTypeImports`
+- Exclude `import type` statements when calculating circular dependencies.
+- Type: `boolean`
+- Default: `false`
+
+
 ## Known Issues
 - Doesn't support [tsconfig.paths](https://www.typescriptlang.org/tsconfig). 
 - Doesn't detect `.ts` imports from `.js` files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.1",
       "dependencies": {
         "d3": "^7.6.1",
-        "madge": "^5.0.1"
+        "madge": "^7.0.0"
       },
       "devDependencies": {
         "@types/d3": "^7.4.0",
@@ -39,14 +39,26 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-4.1.0.tgz",
+      "integrity": "sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -1025,6 +1037,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -1041,7 +1058,7 @@
     "node_modules/app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1058,11 +1075,11 @@
       }
     },
     "node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-5.0.0.tgz",
+      "integrity": "sha512-JvqziE0Wc0rXQfma0HZC/aY7URXHFuZV84fJRtP8u+lhp0JYCNd5wJzVXP45t0PH0Mej3ynlzvdyITYIu0G4LQ==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/atob": {
@@ -1973,7 +1990,8 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/defaults": {
       "version": "1.0.3",
@@ -1992,155 +2010,147 @@
       }
     },
     "node_modules/dependency-tree": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-8.1.2.tgz",
-      "integrity": "sha512-c4CL1IKxkKng0oT5xrg4uNiiMVFqTGOXqHSFx7XEFdgSsp6nw3AGGruICppzJUrfad/r7GLqt26rmWU4h4j39A==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-10.0.9.tgz",
+      "integrity": "sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==",
       "dependencies": {
-        "commander": "^2.20.3",
-        "debug": "^4.3.1",
-        "filing-cabinet": "^3.0.1",
-        "precinct": "^8.0.0",
-        "typescript": "^3.9.7"
+        "commander": "^10.0.1",
+        "filing-cabinet": "^4.1.6",
+        "precinct": "^11.0.5",
+        "typescript": "^5.0.4"
       },
       "bin": {
         "dependency-tree": "bin/cli.js"
       },
       "engines": {
-        "node": "^10.13 || ^12 || >=14"
+        "node": ">=14"
       }
     },
     "node_modules/dependency-tree/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/dependency-tree/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/detective-amd": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.1.2.tgz",
-      "integrity": "sha512-jffU26dyqJ37JHR/o44La6CxtrDf3Rt9tvd2IbImJYxWKTMdBjctp37qoZ6ZcY80RHg+kzWz4bXn39e4P7cctQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-5.0.2.tgz",
+      "integrity": "sha512-XFd/VEQ76HSpym80zxM68ieB77unNuoMwopU2TFT/ErUk5n4KvUTwW4beafAVUugrjV48l4BmmR0rh2MglBaiA==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
+        "ast-module-types": "^5.0.0",
         "escodegen": "^2.0.0",
-        "get-amd-module-type": "^3.0.0",
-        "node-source-walk": "^4.2.0"
+        "get-amd-module-type": "^5.0.1",
+        "node-source-walk": "^6.0.1"
       },
       "bin": {
         "detective-amd": "bin/cli.js"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/detective-cjs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-3.1.3.tgz",
-      "integrity": "sha512-ljs7P0Yj9MK64B7G0eNl0ThWSYjhAaSYy+fQcpzaKalYl/UoQBOzOeLCSFEY1qEBhziZ3w7l46KG/nH+s+L7BQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-5.0.1.tgz",
+      "integrity": "sha512-6nTvAZtpomyz/2pmEmGX1sXNjaqgMplhQkskq2MLrar0ZAIkHMrDhLXkRiK2mvbu9wSWr0V5/IfiTrZqAQMrmQ==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.0.0"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/detective-es6": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-2.2.2.tgz",
-      "integrity": "sha512-eZUKCUsbHm8xoeoCM0z6JFwvDfJ5Ww5HANo+jPR7AzkFpW9Mun3t/TqIF2jjeWa2TFbAiGaWESykf2OQp3oeMw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-4.0.1.tgz",
+      "integrity": "sha512-k3Z5tB4LQ8UVHkuMrFOlvb3GgFWdJ9NqAa2YLUU/jTaWJIm+JJnEh4PsMc+6dfT223Y8ACKOaC0qcj7diIhBKw==",
       "dependencies": {
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       },
       "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/detective-less": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
-      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "gonzales-pe": "^4.2.3",
-        "node-source-walk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0"
+        "node": ">=14"
       }
     },
     "node_modules/detective-postcss": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-5.1.1.tgz",
-      "integrity": "sha512-YJMsvA0Y6/ST9abMNcQytl9iFQ2bfu4I7B74IUiAvyThfaI9Y666yipL+SrqfReoIekeIEwmGH72oeqX63mwUw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.3.tgz",
+      "integrity": "sha512-7BRVvE5pPEvk2ukUWNQ+H2XOq43xENWbH0LcdCE14mwgTBEAMoAx+Fc1rdp76SmyZ4Sp48HlV7VedUnP6GA1Tw==",
       "dependencies": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.6",
-        "postcss-values-parser": "^5.0.0"
+        "postcss": "^8.4.23",
+        "postcss-values-parser": "^6.0.2"
       },
       "engines": {
-        "node": "12.x || 14.x || 16.x"
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/detective-sass": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-3.0.2.tgz",
-      "integrity": "sha512-DNVYbaSlmti/eztFGSfBw4nZvwsTaVXEQ4NsT/uFckxhJrNRFUh24d76KzoCC3aarvpZP9m8sC2L1XbLej4F7g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-5.0.3.tgz",
+      "integrity": "sha512-YsYT2WuA8YIafp2RVF5CEfGhhyIVdPzlwQgxSjK+TUm3JoHP+Tcorbk3SfG0cNZ7D7+cYWa0ZBcvOaR0O8+LlA==",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/detective-scss": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-2.0.2.tgz",
-      "integrity": "sha512-hDWnWh/l0tht/7JQltumpVea/inmkBaanJUcXRB9kEEXVwVUMuZd6z7eusQ6GcBFrfifu3pX/XPyD7StjbAiBg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-4.0.3.tgz",
+      "integrity": "sha512-VYI6cHcD0fLokwqqPFFtDQhhSnlFWvU614J42eY6G0s8c+MBhi9QAWycLwIOGxlmD8I/XvGSOUV1kIDhJ70ZPg==",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/detective-stylus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.3.tgz",
-      "integrity": "sha512-4/bfIU5kqjwugymoxLXXLltzQNeQfxGoLm2eIaqtnkWxqbhap9puDVpJPVDx96hnptdERzS5Cy6p9N8/08A69Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-4.0.0.tgz",
+      "integrity": "sha512-TfPotjhszKLgFBzBhTOxNHDsutIxx9GTWjrL5Wh7Qx/ydxKhwUrlSFeLIn+ZaHPF+h0siVBkAQSuy6CADyTxgQ==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/detective-typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-7.0.2.tgz",
-      "integrity": "sha512-unqovnhxzvkCz3m1/W4QW4qGsvXCU06aU2BAm8tkza+xLnp9SOFnob2QsTxUv5PdnQKfDvWcv9YeOeFckWejwA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-11.2.0.tgz",
+      "integrity": "sha512-ARFxjzizOhPqs1fYC/2NMC3N4jrQ6HvVflnXBTRqNEqJuXwyKLRr9CrJwkRcV/SnZt1sNXgsF6FPm0x57Tq0rw==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "^4.33.0",
-        "ast-module-types": "^2.7.1",
-        "node-source-walk": "^4.2.0",
-        "typescript": "^3.9.10"
+        "@typescript-eslint/typescript-estree": "^5.62.0",
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.2",
+        "typescript": "^5.4.4"
       },
       "engines": {
-        "node": "^10.13 || >=12.0.0"
+        "node": "^14.14.0 || >=16.0.0"
       }
     },
     "node_modules/detective-typescript/node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2148,20 +2158,20 @@
       }
     },
     "node_modules/detective-typescript/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2174,36 +2184,42 @@
       }
     },
     "node_modules/detective-typescript/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/detective-typescript/node_modules/ast-module-types": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.7.1.tgz",
-      "integrity": "sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw=="
+    "node_modules/detective-typescript/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/detective-typescript/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/diff": {
@@ -2308,9 +2324,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -2372,14 +2388,13 @@
       }
     },
     "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "esutils": "^2.0.2"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -2398,53 +2413,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -2538,6 +2506,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2721,7 +2690,8 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -2756,45 +2726,72 @@
       }
     },
     "node_modules/filing-cabinet": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-3.1.0.tgz",
-      "integrity": "sha512-ZFutWTo14Z1xmog76UoQzDKEza1fSpqc+HvUN6K6GILrfhIn6NbR8fHQktltygF+wbt7PZ/EvfLK6yJnebd40A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-4.2.0.tgz",
+      "integrity": "sha512-YZ21ryzRcyqxpyKggdYSoXx//d3sCJzM3lsYoaeg/FyXdADGJrUl+BW1KIglaVLJN5BBcMtWylkygY8zBp2MrQ==",
       "dependencies": {
         "app-module-path": "^2.2.0",
-        "commander": "^2.20.3",
-        "debug": "^4.3.3",
-        "enhanced-resolve": "^5.8.3",
+        "commander": "^10.0.1",
+        "enhanced-resolve": "^5.14.1",
         "is-relative-path": "^1.0.2",
-        "module-definition": "^3.3.1",
-        "module-lookup-amd": "^7.0.1",
-        "resolve": "^1.21.0",
-        "resolve-dependency-path": "^2.0.0",
-        "sass-lookup": "^3.0.0",
-        "stylus-lookup": "^3.0.1",
-        "typescript": "^3.9.7"
+        "module-definition": "^5.0.1",
+        "module-lookup-amd": "^8.0.5",
+        "resolve": "^1.22.3",
+        "resolve-dependency-path": "^3.0.2",
+        "sass-lookup": "^5.0.1",
+        "stylus-lookup": "^5.0.1",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.0.4"
       },
       "bin": {
         "filing-cabinet": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/filing-cabinet/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/filing-cabinet/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/fill-range": {
@@ -2851,12 +2848,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
-    },
-    "node_modules/flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
-      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
-      "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash."
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2937,9 +2928,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -2957,15 +2951,15 @@
       }
     },
     "node_modules/get-amd-module-type": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-3.0.2.tgz",
-      "integrity": "sha512-PcuKwB8ouJnKuAPn6Hk3UtdfKoUV3zXRqVEvj8XGIXqjWfgd1j7QGdXy5Z9OdQfzVt1Sk29HVe/P+X74ccOuqw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-5.0.1.tgz",
+      "integrity": "sha512-jb65zDeHyDjFR1loOVk0HQGM5WNwoGB8aLWy3LKCieMKol0/ProHkhO2X1JxojuN10vbz1qNn09MJ7tNp7qMzw==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.2.2"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/get-caller-file": {
@@ -3098,34 +3092,23 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "node_modules/graphviz": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
-      "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
-      "dependencies": {
-        "temp": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.6.8"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -3277,11 +3260,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indexes-of": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3331,11 +3309,14 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3388,7 +3369,7 @@
     "node_modules/is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3417,7 +3398,7 @@
     "node_modules/is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3425,7 +3406,7 @@
     "node_modules/is-relative-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY="
+      "integrity": "sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA=="
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -3708,54 +3689,41 @@
       }
     },
     "node_modules/madge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/madge/-/madge-5.0.1.tgz",
-      "integrity": "sha512-krmSWL9Hkgub74bOjnjWRoFPAJvPwSG6Dbta06qhWOq6X/n/FPzO3ESZvbFYVIvG2g4UHXvCJN1b+RZLaSs9nA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-7.0.0.tgz",
+      "integrity": "sha512-x9eHkBWoCJ2B8yGesWf8LRucarkbH5P3lazqgvmxe4xn5U2Meyfu906iG9mBB1RnY/f4D+gtELWdiz1k6+jAZA==",
       "dependencies": {
-        "chalk": "^4.1.1",
+        "chalk": "^4.1.2",
         "commander": "^7.2.0",
         "commondir": "^1.0.1",
-        "debug": "^4.3.1",
-        "dependency-tree": "^8.1.1",
-        "detective-amd": "^3.1.0",
-        "detective-cjs": "^3.1.1",
-        "detective-es6": "^2.2.0",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^5.0.0",
-        "detective-sass": "^3.0.1",
-        "detective-scss": "^2.0.1",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^7.0.0",
-        "graphviz": "0.0.9",
+        "debug": "^4.3.4",
+        "dependency-tree": "^10.0.9",
         "ora": "^5.4.1",
         "pluralize": "^8.0.0",
-        "precinct": "^8.1.0",
+        "precinct": "^11.0.5",
         "pretty-ms": "^7.0.1",
-        "rc": "^1.2.7",
-        "typescript": "^3.9.5",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^1.8.1",
         "walkdir": "^0.4.1"
       },
       "bin": {
         "madge": "bin/cli.js"
       },
       "engines": {
-        "node": "^10.13 || ^12 || >=14"
+        "node": ">=14"
       },
       "funding": {
         "type": "individual",
         "url": "https://www.paypal.me/pahen"
-      }
-    },
-    "node_modules/madge/node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
       },
-      "engines": {
-        "node": ">=4.2.0"
+      "peerDependencies": {
+        "typescript": "^3.9.5 || ^4.9.5 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/make-dir": {
@@ -4013,47 +3981,50 @@
       }
     },
     "node_modules/module-definition": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.4.0.tgz",
-      "integrity": "sha512-XxJ88R1v458pifaSkPNLUTdSPNVGMP2SXVncVmApGO+gAfrLANiYe6JofymCzVceGOMwQE2xogxBSc8uB7XegA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-5.0.1.tgz",
+      "integrity": "sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.0.0"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
       },
       "bin": {
         "module-definition": "bin/cli.js"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/module-lookup-amd": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-7.0.1.tgz",
-      "integrity": "sha512-w9mCNlj0S8qviuHzpakaLVc+/7q50jl9a/kmJ/n8bmXQZgDPkQHnPBb8MUOYh3WpAYkXuNc2c+khsozhIp/amQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-8.0.5.tgz",
+      "integrity": "sha512-vc3rYLjDo5Frjox8NZpiyLXsNWJ5BWshztc/5KSOMzpg9k5cHH652YsJ7VKKmtM4SvaxuE9RkrYGhiSjH3Ehow==",
       "dependencies": {
-        "commander": "^2.8.1",
-        "debug": "^4.1.0",
-        "glob": "^7.1.6",
-        "requirejs": "^2.3.5",
+        "commander": "^10.0.1",
+        "glob": "^7.2.3",
+        "requirejs": "^2.3.6",
         "requirejs-config-file": "^4.0.0"
       },
       "bin": {
         "lookup-amd": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/module-lookup-amd/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/module-lookup-amd/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4078,6 +4049,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4145,14 +4117,14 @@
       "dev": true
     },
     "node_modules/node-source-walk": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.3.0.tgz",
-      "integrity": "sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-6.0.2.tgz",
+      "integrity": "sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==",
       "dependencies": {
-        "@babel/parser": "^7.0.0"
+        "@babel/parser": "^7.21.8"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=14"
       }
     },
     "node_modules/normalize-path": {
@@ -4342,9 +4314,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4440,9 +4412,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4451,12 +4423,16 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4878,9 +4854,9 @@
       "dev": true
     },
     "node_modules/postcss-values-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-5.0.0.tgz",
-      "integrity": "sha512-2viDDjMMrt21W2izbeiJxl3kFuD/+asgB0CBwPEgSyhCmBnDIa/y+pLaoyX+q3I3DHH0oPPL3cgjVTQvlS1Maw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
       "dependencies": {
         "color-name": "^1.1.4",
         "is-url-superb": "^4.0.0",
@@ -4890,65 +4866,57 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "postcss": "^8.0.9"
+        "postcss": "^8.2.9"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/precinct": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-8.3.1.tgz",
-      "integrity": "sha512-pVppfMWLp2wF68rwHqBIpPBYY8Kd12lDhk8LVQzOwqllifVR15qNFyod43YLyFpurKRZQKnE7E4pofAagDOm2Q==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-11.0.5.tgz",
+      "integrity": "sha512-oHSWLC8cL/0znFhvln26D14KfCQFFn4KOLSw6hmLhd+LQ2SKt9Ljm89but76Pc7flM9Ty1TnXyrA2u16MfRV3w==",
       "dependencies": {
-        "commander": "^2.20.3",
-        "debug": "^4.3.3",
-        "detective-amd": "^3.1.0",
-        "detective-cjs": "^3.1.1",
-        "detective-es6": "^2.2.1",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^4.0.0",
-        "detective-sass": "^3.0.1",
-        "detective-scss": "^2.0.1",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^7.0.0",
-        "module-definition": "^3.3.1",
-        "node-source-walk": "^4.2.0"
+        "@dependents/detective-less": "^4.1.0",
+        "commander": "^10.0.1",
+        "detective-amd": "^5.0.2",
+        "detective-cjs": "^5.0.1",
+        "detective-es6": "^4.0.1",
+        "detective-postcss": "^6.1.3",
+        "detective-sass": "^5.0.3",
+        "detective-scss": "^4.0.3",
+        "detective-stylus": "^4.0.0",
+        "detective-typescript": "^11.1.0",
+        "module-definition": "^5.0.1",
+        "node-source-walk": "^6.0.2"
       },
       "bin": {
         "precinct": "bin/cli.js"
       },
       "engines": {
-        "node": "^10.13 || ^12 || >=14"
+        "node": "^14.14.0 || >=16.0.0"
       }
     },
     "node_modules/precinct/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/precinct/node_modules/detective-postcss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-4.0.0.tgz",
-      "integrity": "sha512-Fwc/g9VcrowODIAeKRWZfVA/EufxYL7XfuqJQFroBKGikKX83d2G7NFw6kDlSYGG3LNQIyVa+eWv1mqre+v4+A==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "is-url": "^1.2.4",
-        "postcss": "^8.1.7",
-        "postcss-values-parser": "^2.0.1"
-      },
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/precinct/node_modules/postcss-values-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
-      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
-      "dependencies": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.14.4"
+        "node": ">=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -5018,7 +4986,7 @@
     "node_modules/quote-unquote": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
-      "integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs="
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -5119,9 +5087,9 @@
       }
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
       "bin": {
         "r_js": "bin/r.js",
         "r.js": "bin/r.js"
@@ -5149,11 +5117,11 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -5186,11 +5154,11 @@
       }
     },
     "node_modules/resolve-dependency-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz",
-      "integrity": "sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-3.0.2.tgz",
+      "integrity": "sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA==",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/resolve-from": {
@@ -5377,23 +5345,26 @@
       }
     },
     "node_modules/sass-lookup": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
-      "integrity": "sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-5.0.1.tgz",
+      "integrity": "sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==",
       "dependencies": {
-        "commander": "^2.16.0"
+        "commander": "^10.0.1"
       },
       "bin": {
         "sass-lookup": "bin/cli.js"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/sass-lookup/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/sax": {
       "version": "1.2.4",
@@ -5539,9 +5510,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5576,6 +5547,14 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
+    },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5627,7 +5606,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5667,24 +5645,26 @@
       }
     },
     "node_modules/stylus-lookup": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-3.0.2.tgz",
-      "integrity": "sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
+      "integrity": "sha512-tLtJEd5AGvnVy4f9UHQMw4bkJJtaAcmo54N+ovQBjDY3DuWyK9Eltxzr5+KG0q4ew6v2EHyuWWNnHeiw/Eo7rQ==",
       "dependencies": {
-        "commander": "^2.8.1",
-        "debug": "^4.1.0"
+        "commander": "^10.0.1"
       },
       "bin": {
         "stylus-lookup": "bin/cli.js"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/stylus-lookup/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/stylus/node_modules/debug": {
       "version": "3.1.0",
@@ -5768,14 +5748,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/temp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
-      "engines": [
-        "node >=0.4.0"
-      ]
     },
     "node_modules/terser": {
       "version": "5.12.1",
@@ -5888,6 +5860,18 @@
         "node": "*"
       }
     },
+    "node_modules/ts-graphviz": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-1.8.2.tgz",
+      "integrity": "sha512-5YhbFoHmjxa7pgQLkB07MtGnGJ/yhvjmc9uhsnDBEICME6gkPf83SBwLDQqGDoCa3XzUMWLk1AU2Wn1u1naDtA==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ts-graphviz"
+      }
+    },
     "node_modules/ts-loader": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
@@ -5975,9 +5959,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6009,11 +5993,6 @@
       "peerDependencies": {
         "typescript": ">=3.0.0"
       }
-    },
-    "node_modules/uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "node_modules/unzipper": {
       "version": "0.10.11",
@@ -6287,6 +6266,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6399,9 +6379,18 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w=="
+    },
+    "@dependents/detective-less": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-4.1.0.tgz",
+      "integrity": "sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==",
+      "requires": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^6.0.1"
+      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -7209,6 +7198,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -7222,7 +7216,7 @@
     "app-module-path": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -7236,9 +7230,9 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-5.0.0.tgz",
+      "integrity": "sha512-JvqziE0Wc0rXQfma0HZC/aY7URXHFuZV84fJRtP8u+lhp0JYCNd5wJzVXP45t0PH0Mej3ynlzvdyITYIu0G4LQ=="
     },
     "atob": {
       "version": "2.1.2",
@@ -7865,7 +7859,8 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "defaults": {
       "version": "1.0.3",
@@ -7884,148 +7879,137 @@
       }
     },
     "dependency-tree": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-8.1.2.tgz",
-      "integrity": "sha512-c4CL1IKxkKng0oT5xrg4uNiiMVFqTGOXqHSFx7XEFdgSsp6nw3AGGruICppzJUrfad/r7GLqt26rmWU4h4j39A==",
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-10.0.9.tgz",
+      "integrity": "sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==",
       "requires": {
-        "commander": "^2.20.3",
-        "debug": "^4.3.1",
-        "filing-cabinet": "^3.0.1",
-        "precinct": "^8.0.0",
-        "typescript": "^3.9.7"
+        "commander": "^10.0.1",
+        "filing-cabinet": "^4.1.6",
+        "precinct": "^11.0.5",
+        "typescript": "^5.0.4"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         },
         "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
         }
       }
     },
     "detective-amd": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.1.2.tgz",
-      "integrity": "sha512-jffU26dyqJ37JHR/o44La6CxtrDf3Rt9tvd2IbImJYxWKTMdBjctp37qoZ6ZcY80RHg+kzWz4bXn39e4P7cctQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-5.0.2.tgz",
+      "integrity": "sha512-XFd/VEQ76HSpym80zxM68ieB77unNuoMwopU2TFT/ErUk5n4KvUTwW4beafAVUugrjV48l4BmmR0rh2MglBaiA==",
       "requires": {
-        "ast-module-types": "^3.0.0",
+        "ast-module-types": "^5.0.0",
         "escodegen": "^2.0.0",
-        "get-amd-module-type": "^3.0.0",
-        "node-source-walk": "^4.2.0"
+        "get-amd-module-type": "^5.0.1",
+        "node-source-walk": "^6.0.1"
       }
     },
     "detective-cjs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-3.1.3.tgz",
-      "integrity": "sha512-ljs7P0Yj9MK64B7G0eNl0ThWSYjhAaSYy+fQcpzaKalYl/UoQBOzOeLCSFEY1qEBhziZ3w7l46KG/nH+s+L7BQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-5.0.1.tgz",
+      "integrity": "sha512-6nTvAZtpomyz/2pmEmGX1sXNjaqgMplhQkskq2MLrar0ZAIkHMrDhLXkRiK2mvbu9wSWr0V5/IfiTrZqAQMrmQ==",
       "requires": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.0.0"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.0"
       }
     },
     "detective-es6": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-2.2.2.tgz",
-      "integrity": "sha512-eZUKCUsbHm8xoeoCM0z6JFwvDfJ5Ww5HANo+jPR7AzkFpW9Mun3t/TqIF2jjeWa2TFbAiGaWESykf2OQp3oeMw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-4.0.1.tgz",
+      "integrity": "sha512-k3Z5tB4LQ8UVHkuMrFOlvb3GgFWdJ9NqAa2YLUU/jTaWJIm+JJnEh4PsMc+6dfT223Y8ACKOaC0qcj7diIhBKw==",
       "requires": {
-        "node-source-walk": "^4.0.0"
-      }
-    },
-    "detective-less": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
-      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
-      "requires": {
-        "debug": "^4.0.0",
-        "gonzales-pe": "^4.2.3",
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       }
     },
     "detective-postcss": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-5.1.1.tgz",
-      "integrity": "sha512-YJMsvA0Y6/ST9abMNcQytl9iFQ2bfu4I7B74IUiAvyThfaI9Y666yipL+SrqfReoIekeIEwmGH72oeqX63mwUw==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.3.tgz",
+      "integrity": "sha512-7BRVvE5pPEvk2ukUWNQ+H2XOq43xENWbH0LcdCE14mwgTBEAMoAx+Fc1rdp76SmyZ4Sp48HlV7VedUnP6GA1Tw==",
       "requires": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.6",
-        "postcss-values-parser": "^5.0.0"
+        "postcss": "^8.4.23",
+        "postcss-values-parser": "^6.0.2"
       }
     },
     "detective-sass": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-3.0.2.tgz",
-      "integrity": "sha512-DNVYbaSlmti/eztFGSfBw4nZvwsTaVXEQ4NsT/uFckxhJrNRFUh24d76KzoCC3aarvpZP9m8sC2L1XbLej4F7g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-5.0.3.tgz",
+      "integrity": "sha512-YsYT2WuA8YIafp2RVF5CEfGhhyIVdPzlwQgxSjK+TUm3JoHP+Tcorbk3SfG0cNZ7D7+cYWa0ZBcvOaR0O8+LlA==",
       "requires": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       }
     },
     "detective-scss": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-2.0.2.tgz",
-      "integrity": "sha512-hDWnWh/l0tht/7JQltumpVea/inmkBaanJUcXRB9kEEXVwVUMuZd6z7eusQ6GcBFrfifu3pX/XPyD7StjbAiBg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-4.0.3.tgz",
+      "integrity": "sha512-VYI6cHcD0fLokwqqPFFtDQhhSnlFWvU614J42eY6G0s8c+MBhi9QAWycLwIOGxlmD8I/XvGSOUV1kIDhJ70ZPg==",
       "requires": {
         "gonzales-pe": "^4.3.0",
-        "node-source-walk": "^4.0.0"
+        "node-source-walk": "^6.0.1"
       }
     },
     "detective-stylus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.3.tgz",
-      "integrity": "sha512-4/bfIU5kqjwugymoxLXXLltzQNeQfxGoLm2eIaqtnkWxqbhap9puDVpJPVDx96hnptdERzS5Cy6p9N8/08A69Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-4.0.0.tgz",
+      "integrity": "sha512-TfPotjhszKLgFBzBhTOxNHDsutIxx9GTWjrL5Wh7Qx/ydxKhwUrlSFeLIn+ZaHPF+h0siVBkAQSuy6CADyTxgQ=="
     },
     "detective-typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-7.0.2.tgz",
-      "integrity": "sha512-unqovnhxzvkCz3m1/W4QW4qGsvXCU06aU2BAm8tkza+xLnp9SOFnob2QsTxUv5PdnQKfDvWcv9YeOeFckWejwA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-11.2.0.tgz",
+      "integrity": "sha512-ARFxjzizOhPqs1fYC/2NMC3N4jrQ6HvVflnXBTRqNEqJuXwyKLRr9CrJwkRcV/SnZt1sNXgsF6FPm0x57Tq0rw==",
       "requires": {
-        "@typescript-eslint/typescript-estree": "^4.33.0",
-        "ast-module-types": "^2.7.1",
-        "node-source-walk": "^4.2.0",
-        "typescript": "^3.9.10"
+        "@typescript-eslint/typescript-estree": "^5.62.0",
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.2",
+        "typescript": "^5.4.4"
       },
       "dependencies": {
         "@typescript-eslint/types": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+          "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ=="
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+          "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
           "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "@typescript-eslint/visitor-keys": "4.33.0",
-            "debug": "^4.3.1",
-            "globby": "^11.0.3",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.5",
+            "@typescript-eslint/types": "5.62.0",
+            "@typescript-eslint/visitor-keys": "5.62.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
             "tsutils": "^3.21.0"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "4.33.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+          "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
           "requires": {
-            "@typescript-eslint/types": "4.33.0",
-            "eslint-visitor-keys": "^2.0.0"
+            "@typescript-eslint/types": "5.62.0",
+            "eslint-visitor-keys": "^3.3.0"
           }
         },
-        "ast-module-types": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.7.1.tgz",
-          "integrity": "sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw=="
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
         },
         "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
         }
       }
     },
@@ -8118,9 +8102,9 @@
       "dev": true
     },
     "enhanced-resolve": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
-      "integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -8161,14 +8145,13 @@
       "dev": true
     },
     "escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
         "source-map": "~0.6.1"
       },
       "dependencies": {
@@ -8176,41 +8159,6 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-        },
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "requires": {
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "requires": {
-            "prelude-ls": "~1.1.2"
-          }
         }
       }
     },
@@ -8316,7 +8264,8 @@
     "eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true
     },
     "espree": {
       "version": "9.3.3",
@@ -8420,7 +8369,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
@@ -8452,33 +8402,48 @@
       }
     },
     "filing-cabinet": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-3.1.0.tgz",
-      "integrity": "sha512-ZFutWTo14Z1xmog76UoQzDKEza1fSpqc+HvUN6K6GILrfhIn6NbR8fHQktltygF+wbt7PZ/EvfLK6yJnebd40A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-4.2.0.tgz",
+      "integrity": "sha512-YZ21ryzRcyqxpyKggdYSoXx//d3sCJzM3lsYoaeg/FyXdADGJrUl+BW1KIglaVLJN5BBcMtWylkygY8zBp2MrQ==",
       "requires": {
         "app-module-path": "^2.2.0",
-        "commander": "^2.20.3",
-        "debug": "^4.3.3",
-        "enhanced-resolve": "^5.8.3",
+        "commander": "^10.0.1",
+        "enhanced-resolve": "^5.14.1",
         "is-relative-path": "^1.0.2",
-        "module-definition": "^3.3.1",
-        "module-lookup-amd": "^7.0.1",
-        "resolve": "^1.21.0",
-        "resolve-dependency-path": "^2.0.0",
-        "sass-lookup": "^3.0.0",
-        "stylus-lookup": "^3.0.1",
-        "typescript": "^3.9.7"
+        "module-definition": "^5.0.1",
+        "module-lookup-amd": "^8.0.5",
+        "resolve": "^1.22.3",
+        "resolve-dependency-path": "^3.0.2",
+        "sass-lookup": "^5.0.1",
+        "stylus-lookup": "^5.0.1",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.0.4"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+        },
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+        },
+        "tsconfig-paths": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+          "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+          "requires": {
+            "json5": "^2.2.2",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
+          }
         },
         "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
         }
       }
     },
@@ -8521,11 +8486,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
-    },
-    "flatten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
-      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8586,9 +8546,9 @@
       }
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -8606,12 +8566,12 @@
       }
     },
     "get-amd-module-type": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-3.0.2.tgz",
-      "integrity": "sha512-PcuKwB8ouJnKuAPn6Hk3UtdfKoUV3zXRqVEvj8XGIXqjWfgd1j7QGdXy5Z9OdQfzVt1Sk29HVe/P+X74ccOuqw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-5.0.1.tgz",
+      "integrity": "sha512-jb65zDeHyDjFR1loOVk0HQGM5WNwoGB8aLWy3LKCieMKol0/ProHkhO2X1JxojuN10vbz1qNn09MJ7tNp7qMzw==",
       "requires": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.2.2"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
       }
     },
     "get-caller-file": {
@@ -8713,26 +8673,18 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "graphviz": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
-      "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
-      "requires": {
-        "temp": "~0.4.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "he": {
       "version": "1.2.0",
@@ -8825,11 +8777,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
-    "indexes-of": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -8870,11 +8817,11 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
+      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
       }
     },
     "is-extglob": {
@@ -8909,7 +8856,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -8929,12 +8876,12 @@
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA=="
     },
     "is-relative-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
-      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY="
+      "integrity": "sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA=="
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -9153,39 +9100,23 @@
       }
     },
     "madge": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/madge/-/madge-5.0.1.tgz",
-      "integrity": "sha512-krmSWL9Hkgub74bOjnjWRoFPAJvPwSG6Dbta06qhWOq6X/n/FPzO3ESZvbFYVIvG2g4UHXvCJN1b+RZLaSs9nA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-7.0.0.tgz",
+      "integrity": "sha512-x9eHkBWoCJ2B8yGesWf8LRucarkbH5P3lazqgvmxe4xn5U2Meyfu906iG9mBB1RnY/f4D+gtELWdiz1k6+jAZA==",
       "requires": {
-        "chalk": "^4.1.1",
+        "chalk": "^4.1.2",
         "commander": "^7.2.0",
         "commondir": "^1.0.1",
-        "debug": "^4.3.1",
-        "dependency-tree": "^8.1.1",
-        "detective-amd": "^3.1.0",
-        "detective-cjs": "^3.1.1",
-        "detective-es6": "^2.2.0",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^5.0.0",
-        "detective-sass": "^3.0.1",
-        "detective-scss": "^2.0.1",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^7.0.0",
-        "graphviz": "0.0.9",
+        "debug": "^4.3.4",
+        "dependency-tree": "^10.0.9",
         "ora": "^5.4.1",
         "pluralize": "^8.0.0",
-        "precinct": "^8.1.0",
+        "precinct": "^11.0.5",
         "pretty-ms": "^7.0.1",
-        "rc": "^1.2.7",
-        "typescript": "^3.9.5",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^1.8.1",
         "walkdir": "^0.4.1"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.10",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
-        }
       }
     },
     "make-dir": {
@@ -9376,30 +9307,29 @@
       }
     },
     "module-definition": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.4.0.tgz",
-      "integrity": "sha512-XxJ88R1v458pifaSkPNLUTdSPNVGMP2SXVncVmApGO+gAfrLANiYe6JofymCzVceGOMwQE2xogxBSc8uB7XegA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-5.0.1.tgz",
+      "integrity": "sha512-kvw3B4G19IXk+BOXnYq/D/VeO9qfHaapMeuS7w7sNUqmGaA6hywdFHMi+VWeR9wUScXM7XjoryTffCZ5B0/8IA==",
       "requires": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^4.0.0"
+        "ast-module-types": "^5.0.0",
+        "node-source-walk": "^6.0.1"
       }
     },
     "module-lookup-amd": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-7.0.1.tgz",
-      "integrity": "sha512-w9mCNlj0S8qviuHzpakaLVc+/7q50jl9a/kmJ/n8bmXQZgDPkQHnPBb8MUOYh3WpAYkXuNc2c+khsozhIp/amQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-8.0.5.tgz",
+      "integrity": "sha512-vc3rYLjDo5Frjox8NZpiyLXsNWJ5BWshztc/5KSOMzpg9k5cHH652YsJ7VKKmtM4SvaxuE9RkrYGhiSjH3Ehow==",
       "requires": {
-        "commander": "^2.8.1",
-        "debug": "^4.1.0",
-        "glob": "^7.1.6",
-        "requirejs": "^2.3.5",
+        "commander": "^10.0.1",
+        "glob": "^7.2.3",
+        "requirejs": "^2.3.6",
         "requirejs-config-file": "^4.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         },
         "glob": {
           "version": "7.2.3",
@@ -9424,7 +9354,8 @@
     "nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -9479,11 +9410,11 @@
       "dev": true
     },
     "node-source-walk": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.3.0.tgz",
-      "integrity": "sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-6.0.2.tgz",
+      "integrity": "sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==",
       "requires": {
-        "@babel/parser": "^7.0.0"
+        "@babel/parser": "^7.21.8"
       }
     },
     "normalize-path": {
@@ -9616,9 +9547,9 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -9686,13 +9617,20 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "requires": {
-        "nanoid": "^3.3.1",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+          "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+        }
       }
     },
     "postcss-filter-plugins": {
@@ -10022,9 +9960,9 @@
       "dev": true
     },
     "postcss-values-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-5.0.0.tgz",
-      "integrity": "sha512-2viDDjMMrt21W2izbeiJxl3kFuD/+asgB0CBwPEgSyhCmBnDIa/y+pLaoyX+q3I3DHH0oPPL3cgjVTQvlS1Maw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
       "requires": {
         "color-name": "^1.1.4",
         "is-url-superb": "^4.0.0",
@@ -10032,50 +9970,28 @@
       }
     },
     "precinct": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-8.3.1.tgz",
-      "integrity": "sha512-pVppfMWLp2wF68rwHqBIpPBYY8Kd12lDhk8LVQzOwqllifVR15qNFyod43YLyFpurKRZQKnE7E4pofAagDOm2Q==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-11.0.5.tgz",
+      "integrity": "sha512-oHSWLC8cL/0znFhvln26D14KfCQFFn4KOLSw6hmLhd+LQ2SKt9Ljm89but76Pc7flM9Ty1TnXyrA2u16MfRV3w==",
       "requires": {
-        "commander": "^2.20.3",
-        "debug": "^4.3.3",
-        "detective-amd": "^3.1.0",
-        "detective-cjs": "^3.1.1",
-        "detective-es6": "^2.2.1",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^4.0.0",
-        "detective-sass": "^3.0.1",
-        "detective-scss": "^2.0.1",
-        "detective-stylus": "^1.0.0",
-        "detective-typescript": "^7.0.0",
-        "module-definition": "^3.3.1",
-        "node-source-walk": "^4.2.0"
+        "@dependents/detective-less": "^4.1.0",
+        "commander": "^10.0.1",
+        "detective-amd": "^5.0.2",
+        "detective-cjs": "^5.0.1",
+        "detective-es6": "^4.0.1",
+        "detective-postcss": "^6.1.3",
+        "detective-sass": "^5.0.3",
+        "detective-scss": "^4.0.3",
+        "detective-stylus": "^4.0.0",
+        "detective-typescript": "^11.1.0",
+        "module-definition": "^5.0.1",
+        "node-source-walk": "^6.0.2"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "detective-postcss": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-4.0.0.tgz",
-          "integrity": "sha512-Fwc/g9VcrowODIAeKRWZfVA/EufxYL7XfuqJQFroBKGikKX83d2G7NFw6kDlSYGG3LNQIyVa+eWv1mqre+v4+A==",
-          "requires": {
-            "debug": "^4.1.1",
-            "is-url": "^1.2.4",
-            "postcss": "^8.1.7",
-            "postcss-values-parser": "^2.0.1"
-          }
-        },
-        "postcss-values-parser": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
-          "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
-          "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         }
       }
     },
@@ -10120,7 +10036,7 @@
     "quote-unquote": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
-      "integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs="
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10196,9 +10112,9 @@
       "dev": true
     },
     "requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw=="
     },
     "requirejs-config-file": {
       "version": "4.0.0",
@@ -10216,11 +10132,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -10243,9 +10159,9 @@
       }
     },
     "resolve-dependency-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz",
-      "integrity": "sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-3.0.2.tgz",
+      "integrity": "sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA=="
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -10348,17 +10264,17 @@
       }
     },
     "sass-lookup": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
-      "integrity": "sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-5.0.1.tgz",
+      "integrity": "sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==",
       "requires": {
-        "commander": "^2.16.0"
+        "commander": "^10.0.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         }
       }
     },
@@ -10473,9 +10389,9 @@
       "devOptional": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -10505,6 +10421,14 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -10546,8 +10470,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -10615,18 +10538,17 @@
       }
     },
     "stylus-lookup": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-3.0.2.tgz",
-      "integrity": "sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-5.0.1.tgz",
+      "integrity": "sha512-tLtJEd5AGvnVy4f9UHQMw4bkJJtaAcmo54N+ovQBjDY3DuWyK9Eltxzr5+KG0q4ew6v2EHyuWWNnHeiw/Eo7rQ==",
       "requires": {
-        "commander": "^2.8.1",
-        "debug": "^4.1.0"
+        "commander": "^10.0.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         }
       }
     },
@@ -10647,11 +10569,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
-    },
-    "temp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA="
     },
     "terser": {
       "version": "5.12.1",
@@ -10725,6 +10642,11 @@
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
     },
+    "ts-graphviz": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-1.8.2.tgz",
+      "integrity": "sha512-5YhbFoHmjxa7pgQLkB07MtGnGJ/yhvjmc9uhsnDBEICME6gkPf83SBwLDQqGDoCa3XzUMWLk1AU2Wn1u1naDtA=="
+    },
     "ts-loader": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.3.1.tgz",
@@ -10789,9 +10711,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "typescript-plugin-css-modules": {
       "version": "3.4.0",
@@ -10813,11 +10735,6 @@
         "stylus": "^0.54.8",
         "tsconfig-paths": "^3.9.0"
       }
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unzipper": {
       "version": "0.10.11",
@@ -11024,7 +10941,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "workerpool": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
     "watch": "rm -rf dist && webpack --mode development --watch",
     "watch-tests": "rm -rf out && tsc -w -p . --outDir out"
   },
-  "version": "1.1.1"
+  "version": "1.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,21 @@
         "command": "vscode-circular-dependencies-finder.find",
         "title": "Find Circular Dependencies"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Circular Dependencies Finder",
+      "properties": {
+        "circularDependenciesFinder.excludeTypeImports": {
+          "description": "Exclude `import type` statements when calculating circular dependencies.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
   },
   "dependencies": {
     "d3": "^7.6.1",
-    "madge": "^5.0.1"
+    "madge": "^7.0.0"
   },
   "description": "Recursively find circular dependencies in your JavaScript/TypeScript/CSS project.",
   "devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,9 +15,14 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
+      const excludeTypeImports = vscode.workspace
+        .getConfiguration('circularDependenciesFinder')
+        .get<boolean>('excludeTypeImports');
+
       const circularDependencies = await new DependencyFinder(vscode.window, vscode.ProgressLocation)
         .findCircular(
-          filePath
+          filePath,
+          { excludeTypeImports }
         );
 
       new WebView(vscode, context).createPanel(

--- a/src/test/workspace/types/types-a.ts
+++ b/src/test/workspace/types/types-a.ts
@@ -1,0 +1,4 @@
+import type { B } from './types-b';
+
+export type A = `A`;
+export type AB = `${A}${B}`;

--- a/src/test/workspace/types/types-b.ts
+++ b/src/test/workspace/types/types-b.ts
@@ -1,0 +1,4 @@
+import type { C } from './types-c';
+
+export type B = 'B';
+export type BC = `${B}${C}`;

--- a/src/test/workspace/types/types-c.ts
+++ b/src/test/workspace/types/types-c.ts
@@ -1,0 +1,4 @@
+import type { A } from './types-a';
+
+export type C = 'C';
+export type CA = `${C}${A}`;

--- a/src/utils/control-flow-utils/when.ts
+++ b/src/utils/control-flow-utils/when.ts
@@ -1,0 +1,75 @@
+/**
+ * Inspired by the `when` expression in Kotlin, this is an alternative to
+ * `switch` statements, for when you want to use switch-like features in an expression.
+ * Handy in more functional-like programming. It also offers more flexibility than 
+ * a regular `switch` statement.
+ *
+ * @param branches
+ * A list of tuples, where each tuple consists of an expression and a value.
+ * The expression will be evaluated for truthiness.
+ *
+ * @return
+ * The value of the first branch with an expression that evaluates to truthy, or undefined.
+ *
+ * @example
+ * // Without `when`:
+ * const value = 1;
+ * let otherValue;
+ * switch (value) {
+ *   case 0:
+ *     otherValue = 'foo';
+ *     function0();
+ *     break;
+ *   case 1:
+ *     otherValue = 'bar';
+ *     function1();
+ *     break;
+ * }
+ *
+ * // With `when`:
+ * const value = 1;
+ * const otherValue = when(
+ *   [value === 0, () => {
+ *     function0();
+ *     return 'foo';
+ *   }],
+ *   [value === 1, () => {
+ *     function1();
+ *     return 'bar';
+ *   }],
+ * );
+ * 
+ * @see https://kotlinlang.org/docs/control-flow.html#when-expression
+ */
+function when<
+  VALUE = undefined,
+  BRANCHES extends [
+    Branch<NoInfer<VALUE> extends undefined ? unknown : NoInfer<VALUE>>,
+    ...Branch<NoInfer<VALUE> extends undefined ? unknown : NoInfer<VALUE>>[]
+  ] = [
+    Branch<NoInfer<VALUE> extends undefined ? unknown : NoInfer<VALUE>>,
+    ...Branch<NoInfer<VALUE> extends undefined ? unknown : NoInfer<VALUE>>[]
+  ]
+>(
+  ...branches: BRANCHES
+): VALUE extends undefined
+  ? ReturnType<BRANCHES[number][1]> | undefined
+  : VALUE {
+  const branch = branches.find(([expr]) => {
+    let use = false;
+    if (typeof expr === 'function') {
+      use = !!expr();
+    } else {
+      use = !!expr;
+    }
+    return use;
+  });
+
+  return branch?.[1]() as VALUE extends undefined
+    ? ReturnType<BRANCHES[number][1]> | undefined
+    : VALUE;
+}
+
+type Branch<VALUE> = [expression: unknown, value: () => VALUE];
+
+export { when };


### PR DESCRIPTION
Adds a VSCode setting for excluding `import type` statements when calculating circular dependencies. Since types have no effect in runtime, they can in most cases be ignored. Requires type imports to be imported with `import type` to work; type imports using `import` without `type` will always be included.

The newly added setting is a `boolean` with the name `'circularDependenciesFinder.excludeTypeImports'`. It defaults to false, and doesn't change the default behaviour of the extension.

This PR also: 
- Updates the `madge` dependency, as the latest version included some `import type` related fixes.
- Closes #12 by adding a ['quickPick'](https://code.visualstudio.com/api/ux-guidelines/quick-picks) where you select 'in current file' or 'select file' when running the 'Find Circular Dependencies' command.