### PR TITLE
Issue 21: Add 'circularDependenciesFinder.excludeDynamicImports' option to ignore dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Recursively find circular dependencies in your project. Supports the following f
 
 ## Settings
 
+### `circularDependenciesFinder.excludeDynamicImports`
+- Exclude dynamic imports (`import(module)`) when calculating circular dependencies.
+- Type: `boolean`
+- Default: `false`
+
 ### `circularDependenciesFinder.excludeTypeImports`
 - Exclude `import type` statements when calculating circular dependencies.
 - Type: `boolean`

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "configuration": {
       "title": "Circular Dependencies Finder",
       "properties": {
+        "circularDependenciesFinder.excludeDynamicImports": {
+          "description": "Exclude dynamic imports (`import(module)`) when calculating circular dependencies.",
+          "type": "boolean",
+          "default": false
+        },
         "circularDependenciesFinder.excludeTypeImports": {
           "description": "Exclude `import type` statements when calculating circular dependencies.",
           "type": "boolean",

--- a/src/classes/DependencyFinder.ts
+++ b/src/classes/DependencyFinder.ts
@@ -3,6 +3,10 @@ import * as madge from 'madge';
 
 interface FindCircularConfig {
   /**
+   * Exclude dynamic imports (`import(module)`) when calculating circular dependencies.
+   */
+  excludeDynamicImports?: boolean;
+  /**
    * Exclude `import type` statements when calculating circular dependencies.
    */
   excludeTypeImports?: boolean;
@@ -16,14 +20,20 @@ export class DependencyFinder {
 
   _toMadgeConfig(config?: FindCircularConfig): madge.MadgeConfig {
     return {
-      detectiveOptions: config?.excludeTypeImports ? {
+      detectiveOptions: {
         es6: {
-          skipTypeImports: true
+          skipAsyncImports: config?.excludeDynamicImports,
+          skipTypeImports: config?.excludeTypeImports,
         },
         ts: {
-          skipTypeImports: true,
+          skipAsyncImports: config?.excludeDynamicImports,
+          skipTypeImports: config?.excludeTypeImports,
         },
-      } : undefined,
+        tsx: {
+          skipAsyncImports: config?.excludeDynamicImports,
+          skipTypeImports: config?.excludeTypeImports,
+        },
+      },
     };
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,14 +15,15 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
-      const excludeTypeImports = vscode.workspace
+      const extensionConfig = vscode.workspace
         .getConfiguration('circularDependenciesFinder')
-        .get<boolean>('excludeTypeImports');
+      const excludeDynamicImports = extensionConfig.get<boolean>('excludeDynamicImports');
+      const excludeTypeImports = extensionConfig.get<boolean>('excludeTypeImports');
 
       const circularDependencies = await new DependencyFinder(vscode.window, vscode.ProgressLocation)
         .findCircular(
           filePath,
-          { excludeTypeImports }
+          { excludeDynamicImports, excludeTypeImports }
         );
 
       new WebView(vscode, context).createPanel(

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { DependencyFinder } from '../../classes/DependencyFinder';
 
 const dependencyFinder = new DependencyFinder(vscode.window, vscode.ProgressLocation);
-const fileExtensionsToTest = ['css', 'less', 'scss', 'ts', 'js'];
+const fileExtensionsToTest = ['js', 'ts', 'jsx', 'tsx', 'css', 'less', 'scss'];
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
@@ -64,38 +64,73 @@ suite('Extension Test Suite', () => {
   });
 
   suite('Issue #16: DependencyFinder.findCircular() should be able to include and exclude `import type` statements', () => {
-      test('include `import type` statements', async () => {
-        const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
-          ? vscode.workspace.workspaceFolders?.[0].uri.path + `/types/types-a.ts`
-          : null;
+    test('include `import type` statements', async () => {
+      const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
+        ? vscode.workspace.workspaceFolders?.[0].uri.path + `/types/types-a.ts`
+        : null;
 
-        if (!filePath) {
-          assert.fail('No /types/types-a.ts file found. Did you forget to load a workspace?');
-        }
-        
-        const circularDependencies = await dependencyFinder.findCircular(filePath);
-        
-        assert.deepStrictEqual(circularDependencies, [[
-          'types-a.ts',
-          'types-b.ts',
-          'types-c.ts',
-        ]]);
-      });
-
-      test('exclude `import type` statements', async () => {
-        const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
-          ? vscode.workspace.workspaceFolders?.[0].uri.path + `/types/types-a.ts`
-          : null;
-
-        if (!filePath) {
-          assert.fail('No /types/types-a.ts file found. Did you forget to load a workspace?');
-        }
-        
-        const circularDependencies = await dependencyFinder.findCircular(filePath, {
-          excludeTypeImports: true,
-        });
-        
-        assert.deepStrictEqual(circularDependencies, []);
-      });
+      if (!filePath) {
+        assert.fail('No /types/types-a.ts file found. Did you forget to load a workspace?');
+      }
+      
+      const circularDependencies = await dependencyFinder.findCircular(filePath);
+      
+      assert.deepStrictEqual(circularDependencies, [[
+        'types-a.ts',
+        'types-b.ts',
+        'types-c.ts',
+      ]]);
     });
+
+    test('exclude `import type` statements', async () => {
+      const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
+        ? vscode.workspace.workspaceFolders?.[0].uri.path + `/types/types-a.ts`
+        : null;
+
+      if (!filePath) {
+        assert.fail('No /types/types-a.ts file found. Did you forget to load a workspace?');
+      }
+      
+      const circularDependencies = await dependencyFinder.findCircular(filePath, {
+        excludeTypeImports: true,
+      });
+      
+      assert.deepStrictEqual(circularDependencies, []);
+    });
+  });
+
+  suite('Issue #21: DependencyFinder.findCircular() should be able to include and exclude dynamic imports (`import(module)`)', () => {
+    test('include dynamic imports', async () => {
+      const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
+        ? vscode.workspace.workspaceFolders?.[0].uri.path + `/dynamic-imports/a.ts`
+        : null;
+
+      if (!filePath) {
+        assert.fail('No /dynamic-imports/a.ts file found. Did you forget to load a workspace?');
+      }
+      
+      const circularDependencies = await dependencyFinder.findCircular(filePath);
+      
+      assert.deepStrictEqual(circularDependencies, [[
+        'a.ts',
+        'b.ts',
+      ]]);
+    });
+
+    test('exclude dynamic imports', async () => {
+      const filePath = vscode.workspace.workspaceFolders?.[0].uri.path 
+        ? vscode.workspace.workspaceFolders?.[0].uri.path + `/dynamic-imports/a.ts`
+        : null;
+
+      if (!filePath) {
+        assert.fail('No /dynamic-imports/a.ts file found. Did you forget to load a workspace?');
+      }
+      
+      const circularDependencies = await dependencyFinder.findCircular(filePath, {
+        excludeDynamicImports: true,
+      });
+      
+      assert.deepStrictEqual(circularDependencies, []);
+    });
+  });
 });

--- a/src/test/workspace/a/a.jsx
+++ b/src/test/workspace/a/a.jsx
@@ -1,0 +1,9 @@
+import { B } from '../b/b.jsx';
+
+export function A() {
+  return (
+    <div>
+      <B />
+    </div>
+  );
+}

--- a/src/test/workspace/a/a.tsx
+++ b/src/test/workspace/a/a.tsx
@@ -1,0 +1,9 @@
+import { B } from '../b/b.tsx';
+
+export function A() {
+  return (
+    <div>
+      <B />
+    </div>
+  );
+}

--- a/src/test/workspace/b/b.jsx
+++ b/src/test/workspace/b/b.jsx
@@ -1,0 +1,9 @@
+import { A } from '../a/a.jsx';
+
+export function B() {
+  return (
+    <div>
+      <A />
+    </div>
+  );
+}

--- a/src/test/workspace/b/b.tsx
+++ b/src/test/workspace/b/b.tsx
@@ -1,0 +1,9 @@
+import { A } from '../a/a.tsx';
+
+export function B() {
+  return (
+    <div>
+      <A />
+    </div>
+  );
+}

--- a/src/test/workspace/c/c.jsx
+++ b/src/test/workspace/c/c.jsx
@@ -1,0 +1,9 @@
+import { E } from '../e/e.jsx';
+
+export function C() {
+  return (
+    <div>
+      <E />
+    </div>
+  );
+}

--- a/src/test/workspace/c/c.tsx
+++ b/src/test/workspace/c/c.tsx
@@ -1,0 +1,9 @@
+import { E } from '../e/e.tsx';
+
+export function C() {
+  return (
+    <div>
+      <E />
+    </div>
+  );
+}

--- a/src/test/workspace/d/d.jsx
+++ b/src/test/workspace/d/d.jsx
@@ -1,0 +1,9 @@
+import { E } from '../e/e.jsx';
+
+export function D() {
+  return (
+    <div>
+      <E />
+    </div>
+  );
+}

--- a/src/test/workspace/d/d.tsx
+++ b/src/test/workspace/d/d.tsx
@@ -1,0 +1,9 @@
+import { E } from '../e/e.tsx';
+
+export function D() {
+  return (
+    <div>
+      <E />
+    </div>
+  );
+}

--- a/src/test/workspace/dynamic-imports/a.ts
+++ b/src/test/workspace/dynamic-imports/a.ts
@@ -1,0 +1,5 @@
+export function a() {
+  import('./b').then((module) => {
+    console.info('a() calls b', module.b());
+  });
+}

--- a/src/test/workspace/dynamic-imports/b.ts
+++ b/src/test/workspace/dynamic-imports/b.ts
@@ -1,0 +1,5 @@
+export function b() {
+  import('./a').then((module) => {
+    console.info('b() calls a', module.a());
+  });
+}

--- a/src/test/workspace/e/e.jsx
+++ b/src/test/workspace/e/e.jsx
@@ -1,0 +1,9 @@
+import { F } from '../f/f.jsx';
+
+export function E() {
+  return (
+    <div>
+      <F />
+    </div>
+  );
+}

--- a/src/test/workspace/e/e.tsx
+++ b/src/test/workspace/e/e.tsx
@@ -1,0 +1,9 @@
+import { F } from '../f/f.tsx';
+
+export function E() {
+  return (
+    <div>
+      <F />
+    </div>
+  );
+}

--- a/src/test/workspace/f/f.jsx
+++ b/src/test/workspace/f/f.jsx
@@ -1,0 +1,9 @@
+import { D } from '../d/d.jsx';
+
+export function F() {
+  return (
+    <div>
+      <D />
+    </div>
+  );
+}

--- a/src/test/workspace/f/f.tsx
+++ b/src/test/workspace/f/f.tsx
@@ -1,0 +1,9 @@
+import { D } from '../d/d.tsx';
+
+export function F() {
+  return (
+    <div>
+      <D />
+    </div>
+  );
+}

--- a/src/test/workspace/index.jsx
+++ b/src/test/workspace/index.jsx
@@ -1,0 +1,15 @@
+import { A } from './a/a.jsx';
+import { B } from './b/b.jsx';
+import { C } from './c/c.jsx';
+import { D } from './d/d.jsx';
+
+export function Index() {
+  return (
+    <>
+      <A />
+      <B />
+      <C />
+      <D />
+    </>
+  );
+}

--- a/src/test/workspace/index.tsx
+++ b/src/test/workspace/index.tsx
@@ -1,0 +1,15 @@
+import { A } from './a/a.tsx';
+import { B } from './b/b.tsx';
+import { C } from './c/c.tsx';
+import { D } from './d/d.tsx';
+
+export function Index() {
+  return (
+    <>
+      <A />
+      <B />
+      <C />
+      <D />
+    </>
+  );
+}


### PR DESCRIPTION
Closes #21 

Note: there's still additional work to be done in #18 before v.1.3.0 should be released.